### PR TITLE
Fix unwanted nan override of linear_angular_cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ templates/*
 build/*
 
 *autobuild-stamp
+.vscode/
 

--- a/tasks/DeviceMapper.cpp
+++ b/tasks/DeviceMapper.cpp
@@ -120,6 +120,7 @@ void DeviceMapper::updateHook()
 
     controldev::RawCommand cmd;
     base::Vector6d cmd_out = base::Vector6d::Ones() * base::NaN<double>();
+    base::LinearAngular6DCommand unset_cmd = base::commands::LinearAngular6DCommand();
     if(_raw_command.readNewest(cmd) == RTT::NewData)
     {
         try
@@ -200,9 +201,8 @@ void DeviceMapper::updateHook()
             _linear_angular_command.write(linear_angular_cmd);
         case auv_raw_command_converter::KeepAlive:
         case auv_raw_command_converter::Autonomous:
-            linear_angular_cmd.linear = base::Vector3d::Ones() * base::NaN<double>();
-            linear_angular_cmd.angular = base::Vector3d::Ones() * base::NaN<double>();
-            _acc_override_command.write(linear_angular_cmd);
+            unset_cmd.time = linear_angular_cmd.time;
+            _acc_override_command.write(unset_cmd);
             break;
         case auv_raw_command_converter::Timeout:
         default:


### PR DESCRIPTION
This PR is a fix tentative for the issue detailed in https://github.com/rock-control/control-orogen-auv_raw_command_converter/issues/4

As the component does not have any unit tests implemented yet, I would like first to confirm that this is actually an adequate fix and then I can implement the corresponding unit tests.

@saarnold, @gustavoneves12 